### PR TITLE
fix: Update Index.tsx and Glossary.tsx to use generated types

### DIFF
--- a/components/Glossary.tsx
+++ b/components/Glossary.tsx
@@ -1,19 +1,19 @@
 "use client"
 
 import React, { useState } from "react"
-import Link from "next/link"
 
-// --- Interfaces (remain the same) ---
-interface GlossaryEntry {
-    term: string
-    definition?: string
-    see_recipe?: string
-    see_term?: string
-    sub_terms?: string[]
-}
+// 1. Import the generated types from the .d.ts file
+import {
+    CookbookGlossary,
+    GlossaryEntry,
+} from "@/types/generated.ts/glossary-schema"
 
+// 2. The manual interfaces are now removed.
+
+// 3. Update the props to use the imported 'CookbookGlossary' type.
+//    (CookbookGlossary is an alias for GlossaryEntry[])
 interface GlossaryProps {
-    data: GlossaryEntry[]
+    data: CookbookGlossary
 }
 
 const Glossary: React.FC<GlossaryProps> = ({ data }) => {
@@ -23,7 +23,7 @@ const Glossary: React.FC<GlossaryProps> = ({ data }) => {
         return null
     }
 
-    // --- Data Processing (remains the same) ---
+    // This logic works perfectly with the imported types.
     const groupedEntries: { [letter: string]: GlossaryEntry[] } = data.reduce(
         (acc, entry) => {
             const baseLetter = entry.term
@@ -54,20 +54,18 @@ const Glossary: React.FC<GlossaryProps> = ({ data }) => {
             <header
                 className="
                     sticky top-0 z-10 
-                    py-4                  // REDUCED: Vertical padding is now 1rem (was 2rem)
-                    bg-gray-50/95         // ADDED: A slightly transparent background for a modern effect
-                    backdrop-blur-sm      // ADDED: Blurs the content scrolling underneath
+                    py-4
+                    bg-gray-50/95
+                    backdrop-blur-sm
                     border-b border-gray-200
                 "
             >
                 <div className="text-center">
-                    {/* REDUCED: Font size is now 3xl (was 5xl) */}
                     <h1 className="text-3xl font-extrabold text-gray-900">
                         Glossary
                     </h1>
                 </div>
 
-                {/* REDUCED: Margin-top is now 1rem (was 2rem) */}
                 <nav className="filter-nav flex flex-wrap justify-center gap-2 mt-4">
                     <button
                         onClick={() => setSelectedLetter(null)}
@@ -96,9 +94,6 @@ const Glossary: React.FC<GlossaryProps> = ({ data }) => {
             </header>
             <main className="pt-12">
                 {lettersToRender.map((letter) => {
-                    // --- THIS IS THE FIX ---
-                    // A key tracker is created for each letter group to ensure keys are unique
-                    // only among their siblings within that specific group.
                     const keyTracker: { [key: string]: number } = {}
 
                     return (
@@ -108,13 +103,11 @@ const Glossary: React.FC<GlossaryProps> = ({ data }) => {
                             </h2>
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-x-12 gap-y-6">
                                 {groupedEntries[letter].map((entry) => {
-                                    // --- GENERATE THE UNIQUE KEY ---
                                     keyTracker[entry.term] =
                                         (keyTracker[entry.term] || 0) + 1
                                     const uniqueKey = `${entry.term}-${keyTracker[entry.term]}`
 
                                     return (
-                                        // --- USE THE UNIQUE KEY ---
                                         <div
                                             key={uniqueKey}
                                             className="glossary-entry"

--- a/components/Index.tsx
+++ b/components/Index.tsx
@@ -1,28 +1,19 @@
 "use client"
 
 import React, { useState } from "react"
-import Link from "next/link"
 
-// Define the shape of the data this component expects
-interface TermEntry {
-    term: string
-    recipe_number?: string
-}
+// 1. Import the generated types from the .d.ts file
+import {
+    CookbookIndex,
+    IndexEntry,
+    IndexCrossReference,
+} from "@/types/generated.ts/index-schema"
 
-interface CrossReferenceEntry {
-    term: string
-    see?: string
-}
+// 2. The manual interfaces are now removed.
 
-type IndexEntry = TermEntry | CrossReferenceEntry
-
-interface IndexGroup {
-    letter: string
-    entries: IndexEntry[]
-}
-
+// 3. Update the props to use the imported 'CookbookIndex' type
 interface IndexProps {
-    data: IndexGroup[]
+    data: CookbookIndex
 }
 
 const Index: React.FC<IndexProps> = ({ data }) => {
@@ -32,14 +23,19 @@ const Index: React.FC<IndexProps> = ({ data }) => {
         return null
     }
 
-    // The letters are already defined by the data structure!
     const sortedLetters = data.map((group) => group.letter).sort()
     const groupsToRender = selectedLetter
         ? data.filter((group) => group.letter === selectedLetter)
         : data
 
-    // A key tracker for handling potential duplicate terms within a letter group
     const keyTracker: { [key: string]: number } = {}
+
+    // A helper function to act as a type guard
+    const isCrossReference = (
+        entry: IndexEntry
+    ): entry is IndexCrossReference => {
+        return "see" in entry
+    }
 
     return (
         <article className="index max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -94,8 +90,8 @@ const Index: React.FC<IndexProps> = ({ data }) => {
                                         key={uniqueKey}
                                         className="index-entry flex justify-between items-baseline"
                                     >
-                                        {/* Use a type guard to check which kind of entry it is */}
-                                        {"see" in entry ? (
+                                        {/* 4. Use the type guard. This helps TypeScript understand the object's shape. */}
+                                        {isCrossReference(entry) ? (
                                             <span className="text-lg text-gray-600">
                                                 {entry.term}{" "}
                                                 <em>See: {entry.see}</em>
@@ -105,8 +101,8 @@ const Index: React.FC<IndexProps> = ({ data }) => {
                                                 <span className="text-lg text-gray-800">
                                                     {entry.term}
                                                 </span>
-                                                {/* We could make this a link in the future */}
-                                                {"recipe_number" in entry && (
+                                                {/* In this block, TS now knows `entry` is an `IndexTerm`. */}
+                                                {entry.recipe_number && (
                                                     <span className="text-md font-mono text-gray-500">
                                                         {entry.recipe_number}
                                                     </span>


### PR DESCRIPTION
## Summary
Updates `components/Index.tsx` and `components/Glossary.tsx` to use generated TypeScript types from `types/generated.ts/` for better type safety and schema consistency.

## Changes
- Import `GlossaryEntry` from `types/generated.ts/glossary-schema.d.ts`
- Import `IndexEntry` from `types/generated.ts/index-schema.d.ts`
- Remove ad-hoc inline type definitions
- Ensures components align with JSON schema definitions

## Related
- Resolves #13

## Testing
- [x] Components compile with no type errors
- [x] Types imported from generated type definitions
- [x] Application builds successfully