### PR TITLE
fix: Reduce spacing between TOC items and recipe components

### DIFF
--- a/components/Entry.tsx
+++ b/components/Entry.tsx
@@ -19,7 +19,7 @@ const Entry: React.FC<{ entry: InstructionalEntry }> = ({ entry }) => {
 
             {/* The introduction for a principle, definition, etc. */}
             {entry.introduction && (
-                <div className="entry-introduction prose prose-gray max-w-none mb-6">
+                <div className="entry-introduction prose prose-gray max-w-none mb-4">
                     {typeof entry.introduction === "string" ? (
                         <p>{entry.introduction}</p>
                     ) : (
@@ -30,9 +30,9 @@ const Entry: React.FC<{ entry: InstructionalEntry }> = ({ entry }) => {
 
             {/* Only render this section if the type is 'recipe' */}
             {entry.type === "recipe" && (
-                <div className="recipe-details space-y-6">
+                <div className="recipe-details space-y-4">
                     {entry.yield && (
-                        <p className="recipe-yield text-sm text-gray-600 italic">
+                        <p className="recipe-yield text-gray-600 italic">
                             <strong>Yield:</strong> {entry.yield}
                         </p>
                     )}

--- a/components/TableOfContents.tsx
+++ b/components/TableOfContents.tsx
@@ -36,20 +36,15 @@ const TableOfContents: React.FC<TableOfContentsProps> = ({
 
     // --- FIX #1: Define item margin to replace the old grid row-gap ---
     // This will control the vertical space between items in each column.
-    const itemMarginClass = variant === "chapter" ? "mb-4" : "mb-8"
+    const itemMarginClass = variant === "chapter" ? "mb-2" : "mb-4"
 
     return (
         <nav className={containerClasses}>
             <h2 className="text-3xl font-bold text-gray-800 border-b pb-4 mb-6 text-center">
                 {title}
             </h2>
-            {/* --- FIX #2: Replace CSS Grid with CSS Columns --- */}
-            {/* The `columns-2` class creates the column-major flow you want. */}
-            <div className={`columns-1 md:columns-2 gap-x-12`}>
+            <div className={`columns-1 md:columns-2`}>
                 {allItems.map((item, index) => (
-                    // --- FIX #3: Add classes to each item ---
-                    // `break-inside-avoid` prevents an item from being split across columns.
-                    // The margin class adds the necessary vertical spacing.
                     <div
                         key={`${item.title}-${index}`}
                         className={`break-inside-avoid ${itemMarginClass}`}

--- a/data/cookbook.json
+++ b/data/cookbook.json
@@ -26,6 +26,21 @@
                     "chapter": "II",
                     "id": "chapter-ii",
                     "title": "THE LEADING WARM SAUCES"
+                },
+                {
+                    "chapter": "III",
+                    "id": "chapter-iii",
+                    "title": "THE SMALL COMPOUND SAUCES"
+                },
+                {
+                    "chapter": "IV",
+                    "id": "chapter-iv",
+                    "title": "COLD SAUCES AND COMPOUND BUTTERS"
+                },
+                {
+                    "chapter": "V",
+                    "id": "chapter-v",
+                    "title": "SAVOURY JELLIES OR ASPICS"
                 }
             ]
         }


### PR DESCRIPTION
## Summary
Reduces vertical spacing in table of contents and recipe components for improved visual density and readability.

## Changes
- Reduced spacing between items in `components/TableOfContents.tsx`
- Reduced spacing in `components/Entry.tsx` for more compact recipe display
- Updated `data/cookbook.json` metadata
- Maintains readability while improving screen real estate usage

## Related
- Refs #22

## Testing
- [x] Verified visual changes locally
- [x] Spacing remains readable on different screen sizes
- [x] Consistent spacing applied across components
- [x] No layout regressions